### PR TITLE
System Heat compatibility

### DIFF
--- a/GameData/HabTech2/Patches/SystemHeat/SH_Radiators.cfg
+++ b/GameData/HabTech2/Patches/SystemHeat/SH_Radiators.cfg
@@ -1,0 +1,82 @@
+@PART[ht2_radiatorTriple]:NEEDS[SystemHeat]
+{
+  MODULE
+  {
+    name = ModuleSystemHeat
+    volume = 0.1
+    moduleID = default
+    iconName = Icon_Radiator
+    ignoreTemperature = true
+  }
+
+  @MODULE[ModuleActiveRadiator]
+  {
+    @name = ModuleSystemHeatRadiator
+    moduleID = radiator
+    // ModuleSystemHeat instance to link to
+    systemHeatModuleID = default
+    scalarModuleID = heat
+    maxTempAnimation = 500
+
+    // option: use physical or deterministic temperatures
+    // DOES NOT WORK YET
+    // Use emissivity to directly model temp
+    usePhysicalTemperatureModeling = false
+    // maximum temperature system can work at
+    maxRadiatorTemperature = 350
+    // emissivity
+    emissivity = 0.9
+
+    // option: use deterministic temperatures
+    // Power radiated per temperature
+    temperatureCurve
+    {
+      key = 0 0
+      key = 400 340
+    }
+    // area for convection
+    convectiveArea = 143
+  }
+
+}
+
+@PART[ht2_solarArray_duo]:NEEDS[SystemHeat]
+{
+  MODULE
+  {
+    name = ModuleSystemHeat
+    volume = 0.05
+    moduleID = default
+    iconName = Icon_Radiator
+    ignoreTemperature = true
+  }
+
+  @MODULE[ModuleActiveRadiator]
+  {
+    @name = ModuleSystemHeatRadiator
+    moduleID = radiator
+    // ModuleSystemHeat instance to link to
+    systemHeatModuleID = default
+    scalarModuleID = heat
+    maxTempAnimation = 500
+
+    // option: use physical or deterministic temperatures
+    // DOES NOT WORK YET
+    // Use emissivity to directly model temp
+    usePhysicalTemperatureModeling = false
+    // maximum temperature system can work at
+    maxRadiatorTemperature = 350
+    // emissivity
+    emissivity = 0.9
+
+    // option: use deterministic temperatures
+    // Power radiated per temperature
+    temperatureCurve
+    {
+      key = 0 0
+      key = 400 50
+    }
+    // area for convection
+    convectiveArea = 22.5
+  }
+}


### PR DESCRIPTION
Adds System Heat compatibility based on SH patches to stock radiators and estimating relative area. Rads will continue to function as core heat radiators as well.